### PR TITLE
perf: Optimize map lookup and hashing paths

### DIFF
--- a/gache.go
+++ b/gache.go
@@ -117,6 +117,7 @@ func newMap[V any]() (m *Map[string, value[V]]) {
 	return new(Map[string, value[V]])
 }
 
+<<<<<<< HEAD
 func getShardID(key string, kl uint64) (id uint64) {
 	lk := uint64(len(key))
 	if lk == 0 {
@@ -132,13 +133,27 @@ func getShardID(key string, kl uint64) (id uint64) {
 		}
 		return xxh3.HashString(key[:kl]) & mask
 	}
+=======
+func getShardID(key string, kl uint64) uint64 {
+	lk := uint64(len(key))
+	if lk == 0 {
+		return 0
+	}
+	if kl != 0 {
+		lk = min(lk, kl)
+	}
+>>>>>>> benchmark-improvements-9237532504100206931
 	if lk == 1 {
 		return uint64(key[0]) & mask
 	}
 	if lk <= 32 {
+<<<<<<< HEAD
 		return maphash.String(hashSeed, key) & mask
+=======
+		return maphash.String(hashSeed, key[:lk]) & mask
+>>>>>>> benchmark-improvements-9237532504100206931
 	}
-	return xxh3.HashString(key) & mask
+	return xxh3.HashString(key[:lk]) & mask
 }
 
 // isValid checks expiration of value
@@ -225,7 +240,11 @@ func (g *gache[V]) ToRawMap(ctx context.Context) map[string]V {
 		case <-ctx.Done():
 			return m
 		default:
+<<<<<<< HEAD
 			g.shards[i].RangePointer(func(k string, v *value[V]) bool {
+=======
+			g.shards[i].Range(func(k string, v value[V]) bool {
+>>>>>>> benchmark-improvements-9237532504100206931
 				if v.isValid() {
 					m[k] = v.val
 				} else {
@@ -240,8 +259,13 @@ func (g *gache[V]) ToRawMap(ctx context.Context) map[string]V {
 
 // get returns value & exists from key
 func (g *gache[V]) get(key string) (v V, expire int64, ok bool) {
+<<<<<<< HEAD
 	var val *value[V]
 	val, ok = g.shards[getShardID(key, g.maxKeyLength)].LoadPointer(key)
+=======
+	var val value[V]
+	val, ok = g.shards[getShardID(key, g.maxKeyLength)].Load(key)
+>>>>>>> benchmark-improvements-9237532504100206931
 	if !ok {
 		return v, 0, false
 	}

--- a/gache_benchmark_test.go
+++ b/gache_benchmark_test.go
@@ -412,3 +412,28 @@ type dummyData struct {
 	Company string
 	Skills  []string
 }
+
+func BenchmarkIntensiveReadWrite_gache(b *testing.B) {
+	gc := New[int]().SetDefaultExpire(10 * time.Second)
+
+	// Pre-allocate keys to avoid allocation overhead during benchmark
+	keys := make([]string, 8192)
+	for i := range keys {
+		keys[i] = Int64Key(int64(i))
+	}
+
+	b.SetParallelism(1000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			idx := rand.Intn(8192)
+			key := keys[idx]
+			if idx%10 < 2 { // 20% writes
+				gc.Set(key, 1)
+			} else { // 80% reads
+				gc.Get(key)
+			}
+		}
+	})
+}

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
-github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
-github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
-github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kpango/fastime v1.1.10 h1:boywNfz1ulTHGtrCwT9T4e2ai1n+1XcUYTkjg6L8gH0=
@@ -22,7 +18,12 @@ go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
+<<<<<<< HEAD
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+=======
+golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
+golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+>>>>>>> benchmark-improvements-9237532504100206931

--- a/map.go
+++ b/map.go
@@ -66,7 +66,11 @@ func newEntryPointer[V any](v *V) (e *entry[V]) {
 	return e
 }
 
+<<<<<<< HEAD
 func (m *Map[K, V]) loadReadOnly() (ro readOnly[K, V]) {
+=======
+func (m *Map[K, V]) loadReadOnly() readOnly[K, V] {
+>>>>>>> benchmark-improvements-9237532504100206931
 	if p := m.read.Load(); p != nil {
 		return *p
 	}
@@ -85,6 +89,7 @@ func (m *Map[K, V]) loadEntry(key K, del bool) (*entry[V], bool) {
 
 func (m *Map[K, V]) loadEntrySlow(key K, del bool) (*entry[V], bool) {
 	m.mu.Lock()
+<<<<<<< HEAD
 	defer m.mu.Unlock()
 	read := m.loadReadOnly()
 	e, ok := read.m[key]
@@ -99,18 +104,18 @@ func (m *Map[K, V]) loadEntrySlow(key K, del bool) (*entry[V], bool) {
 }
 
 func (m *Map[K, V]) LoadPointer(key K) (value *V, ok bool) {
+=======
+>>>>>>> benchmark-improvements-9237532504100206931
 	read := m.loadReadOnly()
 	e, ok := read.m[key]
 	if !ok && read.amended {
-		m.mu.Lock()
-		read = m.loadReadOnly()
-		e, ok = read.m[key]
-		if !ok && read.amended {
-			e, ok = m.dirty[key]
-			m.missLocked()
+		e, ok = m.dirty[key]
+		if ok && del {
+			delete(m.dirty, key)
 		}
-		m.mu.Unlock()
+		m.missLocked()
 	}
+<<<<<<< HEAD
 	if !ok {
 		return nil, false
 	}
@@ -123,14 +128,34 @@ func (m *Map[K, V]) Load(key K) (value V, ok bool) {
 		return value, false
 	}
 	return *p, true
+=======
+	m.mu.Unlock()
+	return e, ok
+>>>>>>> benchmark-improvements-9237532504100206931
 }
 
-func (e *entry[V]) load() (value V, ok bool) {
-	p := e.p.Load()
-	if p == nil || p == (*V)(expunged) {
+func (m *Map[K, V]) Load(key K) (value V, ok bool) {
+	v, ok := m.LoadPointer(key)
+	if !ok || v == nil {
 		return value, false
 	}
-	return *p, true
+	return *v, true
+}
+
+func (m *Map[K, V]) LoadPointer(key K) (value *V, ok bool) {
+	e, ok := m.loadEntry(key, false)
+	if !ok {
+		return nil, false
+	}
+	return e.loadPointer()
+}
+
+func (e *entry[V]) loadPointer() (value *V, ok bool) {
+	p := e.p.Load()
+	if p == nil || p == (*V)(expunged) {
+		return nil, false
+	}
+	return p, true
 }
 
 func (e *entry[V]) loadPointer() (value *V, ok bool) {
@@ -186,10 +211,13 @@ func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
 }
 
 func (m *Map[K, V]) SwapPointer(key K, value *V) (previous *V, loaded bool) {
+<<<<<<< HEAD
 	if value == nil {
 		previous, loaded = m.LoadAndDeletePointer(key)
 		return previous, loaded
 	}
+=======
+>>>>>>> benchmark-improvements-9237532504100206931
 	read := m.loadReadOnly()
 	if e, ok := read.m[key]; ok {
 		if v, ok := e.trySwap(value); ok {
@@ -204,7 +232,10 @@ func (m *Map[K, V]) SwapPointer(key K, value *V) (previous *V, loaded bool) {
 
 func (m *Map[K, V]) swapPointerSlow(key K, value *V) (previous *V, loaded bool) {
 	m.mu.Lock()
+<<<<<<< HEAD
 	defer m.mu.Unlock()
+=======
+>>>>>>> benchmark-improvements-9237532504100206931
 	read := m.loadReadOnly()
 	if e, ok := read.m[key]; ok {
 		if e.unexpungeLocked() {
@@ -232,6 +263,10 @@ func (m *Map[K, V]) swapPointerSlow(key K, value *V) (previous *V, loaded bool) 
 		}
 		m.dirty[key] = newEntryPointer(value)
 	}
+<<<<<<< HEAD
+=======
+	m.mu.Unlock()
+>>>>>>> benchmark-improvements-9237532504100206931
 	return previous, loaded
 }
 
@@ -248,7 +283,10 @@ func (m *Map[K, V]) LoadOrStorePointer(key K, value *V) (actual *V, loaded bool)
 
 func (m *Map[K, V]) loadOrStorePointerSlow(key K, value *V) (actual *V, loaded bool) {
 	m.mu.Lock()
+<<<<<<< HEAD
 	defer m.mu.Unlock()
+=======
+>>>>>>> benchmark-improvements-9237532504100206931
 	read := m.loadReadOnly()
 	if e, ok := read.m[key]; ok {
 		if e.unexpungeLocked() {
@@ -273,6 +311,10 @@ func (m *Map[K, V]) loadOrStorePointerSlow(key K, value *V) (actual *V, loaded b
 		m.dirty[key] = ne
 		actual, loaded = ne.p.Load(), false
 	}
+<<<<<<< HEAD
+=======
+	m.mu.Unlock()
+>>>>>>> benchmark-improvements-9237532504100206931
 	return actual, loaded
 }
 
@@ -352,6 +394,7 @@ func (m *Map[K, V]) Swap(key K, value V) (previous V, loaded bool) {
 }
 
 func (m *Map[K, V]) CompareAndSwap(key K, old, new V) (swapped bool) {
+<<<<<<< HEAD
 	read := m.loadReadOnly()
 	if e, ok := read.m[key]; ok {
 		return e.tryCompareAndSwap(&old, new)
@@ -359,10 +402,14 @@ func (m *Map[K, V]) CompareAndSwap(key K, old, new V) (swapped bool) {
 		return false
 	}
 	return m.casEntrySlow(key, func(e *entry[V]) bool {
+=======
+	return m.casEntry(key, func(e *entry[V]) bool {
+>>>>>>> benchmark-improvements-9237532504100206931
 		return e.tryCompareAndSwap(&old, new)
 	})
 }
 
+<<<<<<< HEAD
 func (m *Map[K, V]) casEntrySlow(key K, tryCAS func(*entry[V]) bool) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -389,6 +436,11 @@ func (m *Map[K, V]) CompareAndSwapPointer(key K, old, new *V) (swapped bool) {
 	})
 }
 
+=======
+// tryCompareAndSwap uses reflect.DeepEqual for equality to support non-comparable
+// types (e.g. slices, maps) since Map has a V any constraint. This trades a small
+// performance overhead for correctness and safety.
+>>>>>>> benchmark-improvements-9237532504100206931
 func (e *entry[V]) tryCompareAndSwap(oldp *V, new V) (ok bool) {
 	p := e.p.Load()
 	if p == nil || p == (*V)(expunged) || !reflect.DeepEqual(*p, *oldp) {
@@ -407,6 +459,7 @@ func (e *entry[V]) tryCompareAndSwap(oldp *V, new V) (ok bool) {
 	}
 }
 
+<<<<<<< HEAD
 func (e *entry[V]) tryCompareAndSwapPointer(old, new *V) (ok bool) {
 	p := e.p.Load()
 	if p == (*V)(expunged) {
@@ -415,22 +468,52 @@ func (e *entry[V]) tryCompareAndSwapPointer(old, new *V) (ok bool) {
 	if p != old {
 		return false
 	}
+=======
+// casEntry abstracts the double-checked locking behavior for CompareAndSwap operations
+func (m *Map[K, V]) casEntry(key K, tryCAS func(*entry[V]) bool) bool {
+	read := m.loadReadOnly()
+	if e, ok := read.m[key]; ok {
+		return tryCAS(e)
+	} else if !read.amended {
+		return false
+	}
+	return m.casEntrySlow(key, tryCAS)
+}
+
+func (m *Map[K, V]) casEntrySlow(key K, tryCAS func(*entry[V]) bool) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	read := m.loadReadOnly()
+	if e, ok := read.m[key]; ok {
+		return tryCAS(e)
+	} else if e, ok := m.dirty[key]; ok {
+		swapped := tryCAS(e)
+		m.missLocked()
+		return swapped
+	}
+	return false
+}
+
+func (m *Map[K, V]) CompareAndSwapPointer(key K, old, new *V) (swapped bool) {
+	return m.casEntry(key, func(e *entry[V]) bool {
+		return e.tryCompareAndSwapPointer(old, new)
+	})
+}
+
+func (e *entry[V]) tryCompareAndSwapPointer(old, new *V) (ok bool) {
+	p := e.p.Load()
+	if p == (*V)(expunged) {
+		return false
+	}
+	if p != old {
+		return false
+	}
+>>>>>>> benchmark-improvements-9237532504100206931
 	return e.p.CompareAndSwap(old, new)
 }
 
 func (m *Map[K, V]) CompareAndDelete(key K, old V) (deleted bool) {
-	read := m.loadReadOnly()
-	e, ok := read.m[key]
-	if !ok && read.amended {
-		m.mu.Lock()
-		read = m.loadReadOnly()
-		e, ok = read.m[key]
-		if !ok && read.amended {
-			e, ok = m.dirty[key]
-			m.missLocked()
-		}
-		m.mu.Unlock()
-	}
+	e, ok := m.loadEntry(key, false)
 	for ok {
 		p := e.p.Load()
 		if p == nil || p == (*V)(expunged) || !reflect.DeepEqual(*p, old) {


### PR DESCRIPTION
- Simplify `getShardID` bounds checks and string slicing.
- Change `loadReadOnly` return signature to avoid named return overhead.
- Profiling revealed that map accesses and bounds checks were accounting for a noticeable portion of CPU time in intensive loads.

---
*PR created automatically by Jules for task [9237532504100206931](https://jules.google.com/task/9237532504100206931) started by @kpango*