### PR TITLE
Refactor/improve benchmark performance

### DIFF
--- a/gache.go
+++ b/gache.go
@@ -54,12 +54,11 @@ type (
 	gache[V any] struct {
 		shards         [slen]*Map[string, value[V]]
 		cancel         atomic.Pointer[context.CancelFunc]
-		expChan        chan keyValue[V]
+		expChan        chan kv[V]
 		expFunc        func(context.Context, string, V)
 		valPool        *sync.Pool
 		expFuncEnabled bool
 		expire         int64
-		l              uint64
 		maxKeyLength   uint64
 	}
 
@@ -68,7 +67,7 @@ type (
 		expire int64
 	}
 
-	keyValue[V any] struct {
+	kv[V any] struct {
 		key   string
 		value V
 	}
@@ -109,7 +108,7 @@ func New[V any](opts ...Option[V]) Gache[V] {
 	}, opts...) {
 		opt(g)
 	}
-	g.expChan = make(chan keyValue[V], len(g.shards)*10)
+	g.expChan = make(chan kv[V], len(g.shards)*10)
 	return g
 }
 
@@ -190,8 +189,8 @@ func (g *gache[V]) StartExpired(ctx context.Context, dur time.Duration) Gache[V]
 			case <-ctx.Done():
 				tick.Stop()
 				return
-			case kv := <-g.expChan:
-				go g.expFunc(ctx, kv.key, kv.value)
+			case ex := <-g.expChan:
+				go g.expFunc(ctx, ex.key, ex.value)
 			case <-tick.C:
 				go func() {
 					g.DeleteExpired(ctx)
@@ -275,9 +274,7 @@ func (g *gache[V]) set(key string, val V, expire int64) {
 	newVal.val = val
 	newVal.expire = expire
 	old, loaded := shard.SwapPointer(key, newVal)
-	if !loaded {
-		atomic.AddUint64(&g.l, 1)
-	} else {
+	if loaded {
 		old.reset()
 		g.valPool.Put(old)
 	}
@@ -296,9 +293,9 @@ func (g *gache[V]) Set(key string, val V) {
 // Delete deletes value from Gache using key
 func (g *gache[V]) Delete(key string) (v V, loaded bool) {
 	var val *value[V]
-	val, loaded = g.shards[getShardID(key, g.maxKeyLength)].LoadAndDeletePointer(key)
+	shard := g.shards[getShardID(key, g.maxKeyLength)]
+	val, loaded = shard.LoadAndDeletePointer(key)
 	if loaded {
-		atomic.AddUint64(&g.l, ^uint64(0))
 		v = val.val
 		val.reset()
 		g.valPool.Put(val)
@@ -310,19 +307,17 @@ func (g *gache[V]) Delete(key string) (v V, loaded bool) {
 func (g *gache[V]) expiration(key string) {
 	v, loaded := g.Delete(key)
 	if loaded && g.expFuncEnabled {
-		g.expChan <- keyValue[V]{key: key, value: v}
+		g.expChan <- kv[V]{key: key, value: v}
 	}
 }
 
 // DeleteExpired deletes expired value from Gache it can be cancel using context
 func (g *gache[V]) DeleteExpired(ctx context.Context) (rows uint64) {
 	var wg sync.WaitGroup
-	for i := range g.shards {
-		wg.Add(1)
-		go func(c context.Context, idx int) {
-			defer wg.Done()
+	for idx := range g.shards {
+		wg.Go(func() {
 			select {
-			case <-c.Done():
+			case <-ctx.Done():
 				return
 			default:
 				g.shards[idx].RangePointer(func(k string, v *value[V]) (ok bool) {
@@ -333,7 +328,7 @@ func (g *gache[V]) DeleteExpired(ctx context.Context) (rows uint64) {
 					return true
 				})
 			}
-		}(ctx, i)
+		})
 	}
 	wg.Wait()
 	return atomic.LoadUint64(&rows)
@@ -341,13 +336,11 @@ func (g *gache[V]) DeleteExpired(ctx context.Context) (rows uint64) {
 
 // Range calls f sequentially for each key and value present in the Gache.
 func (g *gache[V]) Range(ctx context.Context, f func(string, V, int64) bool) Gache[V] {
-	wg := new(sync.WaitGroup)
-	for i := range g.shards {
-		wg.Add(1)
-		go func(c context.Context, idx int) {
-			defer wg.Done()
+	var wg sync.WaitGroup
+	for idx := range g.shards {
+		wg.Go(func() {
 			select {
-			case <-c.Done():
+			case <-ctx.Done():
 				return
 			default:
 				g.shards[idx].RangePointer(func(k string, v *value[V]) (ok bool) {
@@ -358,24 +351,25 @@ func (g *gache[V]) Range(ctx context.Context, f func(string, V, int64) bool) Gac
 					return true
 				})
 			}
-		}(ctx, i)
+		})
 	}
 	wg.Wait()
 	return g
 }
 
 // Len returns stored object length
-func (g *gache[V]) Len() int {
-	l := atomic.LoadUint64(&g.l)
-	return *(*int)(unsafe.Pointer(&l))
+func (g *gache[V]) Len() (l int) {
+	for i := range g.shards {
+		l += g.shards[i].Len()
+	}
+	return l
 }
 
 func (g *gache[V]) Size() (size uintptr) {
 	size += unsafe.Sizeof(g.expFuncEnabled) // bool
 	size += unsafe.Sizeof(g.expire)         // int64
-	size += unsafe.Sizeof(g.l)              // uint64
 	size += unsafe.Sizeof(g.cancel)         // atomic.Pointer[context.CancelFunc]
-	size += unsafe.Sizeof(g.expChan)        // chan keyValue[V]
+	size += unsafe.Sizeof(g.expChan)        // chan kv[V]
 	size += unsafe.Sizeof(g.expFunc)        // func(context.Context, string, V)
 	for _, shard := range g.shards {
 		size += shard.Size()
@@ -421,7 +415,6 @@ func (g *gache[V]) Clear() {
 			g.shards[i].Clear()
 		}
 	}
-	atomic.StoreUint64(&g.l, 0)
 }
 
 func (v *value[V]) Size() (size uintptr) {
@@ -511,11 +504,11 @@ func (g *gache[V]) Keys(ctx context.Context) []string {
 
 // Pop returns value & exists from key and deletes it.
 func (g *gache[V]) Pop(key string) (v V, ok bool) {
-	val, loaded := g.shards[getShardID(key, g.maxKeyLength)].LoadAndDeletePointer(key)
+	shard := g.shards[getShardID(key, g.maxKeyLength)]
+	val, loaded := shard.LoadAndDeletePointer(key)
 	if !loaded {
 		return v, false
 	}
-	atomic.AddUint64(&g.l, ^uint64(0))
 	v = val.val
 	valid := val.isValid()
 	val.reset()
@@ -524,7 +517,7 @@ func (g *gache[V]) Pop(key string) (v V, ok bool) {
 		return v, true
 	}
 	if g.expFuncEnabled {
-		g.expChan <- keyValue[V]{key: key, value: v}
+		g.expChan <- kv[V]{key: key, value: v}
 	}
 	return v, false
 }
@@ -549,7 +542,6 @@ func (g *gache[V]) SetWithExpireIfNotExists(key string, val V, d time.Duration) 
 	for {
 		actual, loaded := shard.LoadOrStorePointer(key, newVal)
 		if !loaded {
-			atomic.AddUint64(&g.l, 1)
 			return
 		}
 

--- a/gache_benchmark_test.go
+++ b/gache_benchmark_test.go
@@ -1,17 +1,18 @@
 package gache
 
 import (
+	"flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"runtime"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
-	"unsafe"
 )
 
 type DefaultMap struct {
@@ -38,30 +39,60 @@ func (m *DefaultMap) Set(key, val any) {
 	m.data[key] = val
 }
 
+// benchParallelismFlag holds the raw flag value for -benchparallelism.
+var benchParallelismFlag string
+
+// parallelismValues is the set of parallelism levels used by all benchmarks.
+// It is populated from -benchparallelism (comma-separated integers) in
+// TestMain; see TestMain for the current default values.
+var parallelismValues []int
+
+// keyValue holds a pre-computed key-value pair for deterministic benchmark iteration.
+type keyValue struct {
+	key   string
+	value string
+}
+
 var (
 	ttl time.Duration = 50 * time.Millisecond
 
-	parallelism = 10000
-
-	bigData      = map[string]string{}
-	bigDataLen   = 2 << 10
-	bigDataCount = 2 << 16
-
-	smallData = map[string]string{
-		"string": "aaaa",
-		"int":    "123",
-		"float":  "99.99",
-		"struct": "struct{}{}",
-	}
+	// Pre-computed slices for deterministic iteration order in benchmarks.
+	smallData []keyValue
+	bigData   []keyValue
 )
 
 func init() {
+	flag.StringVar(&benchParallelismFlag, "benchparallelism", "", "comma-separated list of parallelism values for benchmarks (default: 100,1000,5000,10000)")
+
+	var (
+		bigDataLen     = 2 << 10
+		bigDataCount   = 2 << 16
+		smallDataLen   = 2 << 5
+		smallDataCount = 2 << 3
+	)
+	bigData = make([]keyValue, 0, bigDataCount)
 	for range bigDataCount {
-		bigData[randStr(bigDataLen)] = randStr(bigDataLen)
+		bigData = append(bigData, keyValue{
+			key:   randStr(bigDataLen),
+			value: randStr(bigDataLen),
+		})
 	}
+	slices.SortFunc(bigData, func(a, b keyValue) int {
+		return strings.Compare(a.key, b.key)
+	})
+	smallData = make([]keyValue, 0, smallDataCount)
+	for range smallDataCount {
+		smallData = append(smallData, keyValue{
+			key:   randStr(smallDataLen),
+			value: randStr(smallDataLen),
+		})
+	}
+	slices.SortFunc(smallData, func(a, b keyValue) int {
+		return strings.Compare(a.key, b.key)
+	})
 }
 
-var randSrc = rand.NewSource(time.Now().UnixNano())
+var randSrc = rand.NewSource(42)
 
 const (
 	rs6Letters       = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -85,28 +116,35 @@ func randStr(n int) string {
 		cache >>= rs6LetterIdxBits
 		remain--
 	}
-	return *(*string)(unsafe.Pointer(&b))
+	return string(b)
 }
 
-func benchmark(b *testing.B, data map[string]string,
+// benchmark runs a mixed set-and-get workload benchmark for each configured
+// parallelism value, emitting sub-benchmarks named "P<n>".
+func benchmark(b *testing.B, data []keyValue,
 	t time.Duration,
 	set func(string, string, time.Duration),
 	get func(string),
 ) {
 	b.Helper()
-	b.SetParallelism(parallelism)
-	b.ReportAllocs()
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			for k, v := range data {
-				set(k, v, t)
-			}
-			for k := range data {
-				get(k)
-			}
-		}
-	})
+	for _, p := range parallelismValues {
+		b.Run(fmt.Sprintf("P%d", p), func(b *testing.B) {
+			b.SetParallelism(p)
+			b.ReportAllocs()
+			runtime.GC()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					for _, kv := range data {
+						set(kv.key, kv.value, t)
+					}
+					for _, kv := range data {
+						get(kv.key)
+					}
+				}
+			})
+		})
+	}
 }
 
 func BenchmarkDefaultMapSetSmallDataNoTTL(b *testing.B) {
@@ -178,6 +216,18 @@ func BenchmarkGacheSetBigDataWithTTL(b *testing.B) {
 }
 
 func TestMain(m *testing.M) {
+	flag.Parse()
+	if benchParallelismFlag != "" {
+		for s := range strings.SplitSeq(benchParallelismFlag, ",") {
+			v, err := strconv.Atoi(strings.TrimSpace(s))
+			if err == nil && v > 0 {
+				parallelismValues = append(parallelismValues, v)
+			}
+		}
+	}
+	if len(parallelismValues) == 0 {
+		parallelismValues = []int{100, 1000, 5000, 10000}
+	}
 	setup()
 	code := m.Run()
 	shutdown()

--- a/gache_test.go
+++ b/gache_test.go
@@ -1,8 +1,12 @@
 package gache
 
 import (
+	"fmt"
+	"math/rand"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 // TestGetShardID_MaxKeyLengthZero tests getShardID when maxKeyLength (kl) is 0,
@@ -228,5 +232,214 @@ func TestGetShardID_PrefixIsolation(t *testing.T) {
 	id4 := getShardID(key4, 50)
 	if id3 != id4 {
 		t.Errorf("prefix isolation (xxh3) failed: getShardID(%q, 50)=%d != getShardID(%q, 50)=%d", key3, id3, key4, id4)
+	}
+}
+
+func TestGacheLenBasic(t *testing.T) {
+	t.Parallel()
+	g := New[int](WithDefaultExpiration[int](NoTTL))
+
+	if got := g.Len(); got != 0 {
+		t.Fatalf("empty gache Len() = %d, want 0", got)
+	}
+
+	// Set increments
+	g.Set("a", 1)
+	g.Set("b", 2)
+	g.Set("c", 3)
+	if got := g.Len(); got != 3 {
+		t.Fatalf("after 3 Sets, Len() = %d, want 3", got)
+	}
+
+	// Overwrite does not change count
+	g.Set("b", 20)
+	if got := g.Len(); got != 3 {
+		t.Fatalf("after overwrite, Len() = %d, want 3", got)
+	}
+
+	// Delete decrements
+	g.Delete("a")
+	if got := g.Len(); got != 2 {
+		t.Fatalf("after Delete, Len() = %d, want 2", got)
+	}
+
+	// Delete non-existent key is a no-op
+	g.Delete("nonexistent")
+	if got := g.Len(); got != 2 {
+		t.Fatalf("after Delete(nonexistent), Len() = %d, want 2", got)
+	}
+
+	// Pop decrements
+	if _, ok := g.Pop("b"); !ok {
+		t.Fatal("Pop(b) returned ok=false")
+	}
+	if got := g.Len(); got != 1 {
+		t.Fatalf("after Pop, Len() = %d, want 1", got)
+	}
+
+	// SetIfNotExists with new key increments
+	g.SetIfNotExists("d", 4)
+	if got := g.Len(); got != 2 {
+		t.Fatalf("after SetIfNotExists(new), Len() = %d, want 2", got)
+	}
+
+	// SetIfNotExists with existing key does not change count
+	g.SetIfNotExists("d", 40)
+	if got := g.Len(); got != 2 {
+		t.Fatalf("after SetIfNotExists(existing), Len() = %d, want 2", got)
+	}
+
+	// Clear resets to 0
+	g.Clear()
+	if got := g.Len(); got != 0 {
+		t.Fatalf("after Clear, Len() = %d, want 0", got)
+	}
+}
+
+func TestGacheLenConcurrent(t *testing.T) {
+	t.Parallel()
+	g := New[int](WithDefaultExpiration[int](NoTTL)).(*gache[int])
+
+	const (
+		numGoroutines   = 16
+		opsPerGoroutine = 1000
+		keyRange        = 200
+	)
+
+	var wg sync.WaitGroup
+	for id := range numGoroutines {
+		wg.Go(func() {
+			r := rand.New(rand.NewSource(int64(id)))
+			for i := range opsPerGoroutine {
+				key := fmt.Sprintf("key-%d", r.Intn(keyRange))
+				switch r.Intn(2) {
+				case 0:
+					g.Set(key, i)
+				case 1:
+					g.Delete(key)
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	// Verify Len matches actual count from Range
+	actual := 0
+	for i := range g.shards {
+		g.shards[i].Range(func(k string, v value[int]) bool {
+			actual++
+			return true
+		})
+	}
+
+	if got := g.Len(); got != actual {
+		t.Fatalf("after concurrent ops, Len() = %d, but counted %d entries", got, actual)
+	}
+}
+
+func TestGacheLenConcurrentStoreDelete(t *testing.T) {
+	t.Parallel()
+	g := New[int](WithDefaultExpiration[int](NoTTL)).(*gache[int])
+
+	const (
+		numGoroutines    = 8
+		keysPerGoroutine = 500
+	)
+
+	// Phase 1: Store unique keys concurrently
+	var wg sync.WaitGroup
+	for id := range numGoroutines {
+		wg.Go(func() {
+			base := id * keysPerGoroutine
+			for i := range keysPerGoroutine {
+				g.Set(fmt.Sprintf("key-%d", base+i), i)
+			}
+		})
+	}
+	wg.Wait()
+
+	total := numGoroutines * keysPerGoroutine
+	if got := g.Len(); got != total {
+		t.Fatalf("after storing %d unique keys, Len() = %d", total, got)
+	}
+
+	// Phase 2: Delete all keys concurrently
+	for id := range numGoroutines {
+		wg.Go(func() {
+			base := id * keysPerGoroutine
+			for i := range keysPerGoroutine {
+				g.Delete(fmt.Sprintf("key-%d", base+i))
+			}
+		})
+	}
+	wg.Wait()
+
+	if got := g.Len(); got != 0 {
+		t.Fatalf("after deleting all keys, Len() = %d, want 0", got)
+	}
+}
+
+func TestGacheLenClearConcurrent(t *testing.T) {
+	t.Parallel()
+	g := New[int](WithDefaultExpiration[int](NoTTL)).(*gache[int])
+
+	const (
+		numWriters  = 4
+		numDeleters = 4
+		clearCycles = 200
+	)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writers
+	for id := range numWriters {
+		wg.Go(func() {
+			r := rand.New(rand.NewSource(int64(id)))
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					g.Set(fmt.Sprintf("k-%d", r.Intn(100)), id)
+				}
+			}
+		})
+	}
+
+	// Deleters
+	for id := range numDeleters {
+		wg.Go(func() {
+			r := rand.New(rand.NewSource(int64(id + 100)))
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					g.Delete(fmt.Sprintf("k-%d", r.Intn(100)))
+				}
+			}
+		})
+	}
+
+	// Periodically Clear
+	for range clearCycles {
+		g.Clear()
+		time.Sleep(time.Microsecond)
+	}
+
+	close(done)
+	wg.Wait()
+
+	// Final check: Len matches actual count after all goroutines have stopped
+	actual := 0
+	for i := range g.shards {
+		g.shards[i].Range(func(k string, v value[int]) bool {
+			actual++
+			return true
+		})
+	}
+	if got := g.Len(); got != actual {
+		t.Fatalf("final Len() = %d, counted %d entries", got, actual)
 	}
 }

--- a/map.go
+++ b/map.go
@@ -41,6 +41,7 @@ type Map[K comparable, V any] struct {
 	mu     sync.RWMutex
 	dirty  map[K]*entry[V]
 	misses int
+	l      atomic.Uint64 // shard counter
 }
 
 type readOnly[K comparable, V any] struct {
@@ -167,6 +168,7 @@ func (m *Map[K, V]) Clear() {
 	clear(m.dirty)
 	// Don't immediately promote the newly-cleared dirty map on the next operation.
 	m.misses = 0
+	m.l.Store(0)
 }
 
 func (e *entry[V]) unexpungeLocked() (wasExpunged bool) {
@@ -194,12 +196,17 @@ func (m *Map[K, V]) SwapPointer(key K, value *V) (previous *V, loaded bool) {
 	if e, ok := read.m[key]; ok {
 		if v, ok := e.trySwap(value); ok {
 			if v == nil {
+				m.l.Add(1)
 				return nil, false
 			}
 			return v, true
 		}
 	}
-	return m.swapPointerSlow(key, value)
+	previous, loaded = m.swapPointerSlow(key, value)
+	if !loaded {
+		m.l.Add(1)
+	}
+	return previous, loaded
 }
 
 func (m *Map[K, V]) swapPointerSlow(key K, value *V) (previous *V, loaded bool) {
@@ -240,10 +247,17 @@ func (m *Map[K, V]) LoadOrStorePointer(key K, value *V) (actual *V, loaded bool)
 	if e, ok := read.m[key]; ok {
 		actual, loaded, ok := e.tryLoadOrStorePointer(value)
 		if ok {
+			if !loaded {
+				m.l.Add(1)
+			}
 			return actual, loaded
 		}
 	}
-	return m.loadOrStorePointerSlow(key, value)
+	actual, loaded = m.loadOrStorePointerSlow(key, value)
+	if !loaded {
+		m.l.Add(1)
+	}
+	return actual, loaded
 }
 
 func (m *Map[K, V]) loadOrStorePointerSlow(key K, value *V) (actual *V, loaded bool) {
@@ -310,7 +324,11 @@ func (m *Map[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
 func (m *Map[K, V]) LoadAndDeletePointer(key K) (value *V, loaded bool) {
 	e, ok := m.loadEntry(key, true)
 	if ok && e != nil {
-		return e.deletePointer()
+		value, loaded = e.deletePointer()
+		if loaded {
+			m.l.Add(^uint64(0))
+		}
+		return value, loaded
 	}
 	return nil, false
 }
@@ -437,6 +455,7 @@ func (m *Map[K, V]) CompareAndDelete(key K, old V) (deleted bool) {
 			return false
 		}
 		if e.p.CompareAndSwap(p, nil) {
+			m.l.Add(^uint64(0))
 			return true
 		}
 	}
@@ -515,20 +534,7 @@ func (e *entry[V]) tryExpungeLocked() (isExpunged bool) {
 }
 
 func (m *Map[K, V]) Len() int {
-	read := m.loadReadOnly()
-	if read.amended {
-		m.mu.Lock()
-		read = m.loadReadOnly()
-		if read.amended {
-			read = readOnly[K, V]{m: m.dirty}
-			m.read.Store(&read)
-			m.dirty = nil
-			m.misses = 0
-		}
-		m.mu.Unlock()
-	}
-
-	return len(read.m)
+	return int(m.l.Load())
 }
 
 func (m *Map[K, V]) Size() (size uintptr) {
@@ -537,7 +543,7 @@ func (m *Map[K, V]) Size() (size uintptr) {
 	}
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	size = unsafe.Sizeof(*m) // Includes mu, read, dirty, misses
+	size = unsafe.Sizeof(*m) // Includes mu, read, dirty, misses, l
 
 	if ro := m.read.Load(); ro != nil {
 		size += ro.Size()

--- a/map_test.go
+++ b/map_test.go
@@ -182,9 +182,7 @@ func TestConcurrentRange(t *testing.T) {
 	}()
 	for g := int64(runtime.GOMAXPROCS(0)); g > 0; g-- {
 		r := rand.New(rand.NewSource(g))
-		wg.Add(1)
-		go func(g int64) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := int64(0); ; i++ {
 				select {
 				case <-done:
@@ -199,7 +197,7 @@ func TestConcurrentRange(t *testing.T) {
 					}
 				}
 			}
-		}(g)
+		})
 	}
 
 	iters := 1 << 10
@@ -305,5 +303,258 @@ func TestCompareAndSwap_NonExistingKey(t *testing.T) {
 	if m.CompareAndSwap(m, nil, 42) {
 		// See https://go.dev/issue/51972#issuecomment-1126408637.
 		t.Fatalf("CompareAndSwap on an non-existing key succeeded")
+	}
+}
+
+func TestMapLenBasic(t *testing.T) {
+	var m gache.Map[string, int]
+
+	if got := m.Len(); got != 0 {
+		t.Fatalf("empty map Len() = %d, want 0", got)
+	}
+
+	// Store increments
+	m.Store("a", 1)
+	m.Store("b", 2)
+	m.Store("c", 3)
+	if got := m.Len(); got != 3 {
+		t.Fatalf("after 3 Stores, Len() = %d, want 3", got)
+	}
+
+	// Overwrite does not change count
+	m.Store("b", 20)
+	if got := m.Len(); got != 3 {
+		t.Fatalf("after overwrite, Len() = %d, want 3", got)
+	}
+
+	// Delete decrements
+	m.Delete("a")
+	if got := m.Len(); got != 2 {
+		t.Fatalf("after Delete, Len() = %d, want 2", got)
+	}
+
+	// Delete non-existent key is a no-op
+	m.Delete("nonexistent")
+	if got := m.Len(); got != 2 {
+		t.Fatalf("after Delete(nonexistent), Len() = %d, want 2", got)
+	}
+
+	// LoadAndDelete decrements
+	if _, ok := m.LoadAndDelete("b"); !ok {
+		t.Fatal("LoadAndDelete(b) returned ok=false")
+	}
+	if got := m.Len(); got != 1 {
+		t.Fatalf("after LoadAndDelete, Len() = %d, want 1", got)
+	}
+
+	// LoadOrStore with new key increments
+	if _, loaded := m.LoadOrStore("d", 4); loaded {
+		t.Fatal("LoadOrStore(d) returned loaded=true for new key")
+	}
+	if got := m.Len(); got != 2 {
+		t.Fatalf("after LoadOrStore(new), Len() = %d, want 2", got)
+	}
+
+	// LoadOrStore with existing key does not change count
+	if _, loaded := m.LoadOrStore("d", 40); !loaded {
+		t.Fatal("LoadOrStore(d) returned loaded=false for existing key")
+	}
+	if got := m.Len(); got != 2 {
+		t.Fatalf("after LoadOrStore(existing), Len() = %d, want 2", got)
+	}
+
+	// Swap with new key increments
+	if _, loaded := m.Swap("e", 5); loaded {
+		t.Fatal("Swap(e) returned loaded=true for new key")
+	}
+	if got := m.Len(); got != 3 {
+		t.Fatalf("after Swap(new), Len() = %d, want 3", got)
+	}
+
+	// Swap with existing key does not change count
+	if _, loaded := m.Swap("e", 50); !loaded {
+		t.Fatal("Swap(e) returned loaded=false for existing key")
+	}
+	if got := m.Len(); got != 3 {
+		t.Fatalf("after Swap(existing), Len() = %d, want 3", got)
+	}
+
+	// CompareAndDelete decrements
+	if !m.CompareAndDelete("e", 50) {
+		t.Fatal("CompareAndDelete(e, 50) returned false")
+	}
+	if got := m.Len(); got != 2 {
+		t.Fatalf("after CompareAndDelete, Len() = %d, want 2", got)
+	}
+
+	// CompareAndDelete with wrong value is a no-op
+	if m.CompareAndDelete("c", 999) {
+		t.Fatal("CompareAndDelete with wrong value returned true")
+	}
+	if got := m.Len(); got != 2 {
+		t.Fatalf("after CompareAndDelete(wrong), Len() = %d, want 2", got)
+	}
+
+	// Clear resets to 0
+	m.Clear()
+	if got := m.Len(); got != 0 {
+		t.Fatalf("after Clear, Len() = %d, want 0", got)
+	}
+}
+
+func TestMapLenConcurrent(t *testing.T) {
+	var m gache.Map[int, int]
+
+	const (
+		numGoroutines   = 16
+		opsPerGoroutine = 1000
+		keyRange        = 200
+	)
+
+	var wg sync.WaitGroup
+
+	// Half goroutines do Store, the other half do Delete, all on a shared key range.
+	// After all goroutines complete, verify that Len() matches the actual map contents.
+	for id := range numGoroutines {
+		wg.Go(func() {
+			r := rand.New(rand.NewSource(int64(id)))
+			for i := range opsPerGoroutine {
+				key := r.Intn(keyRange)
+				switch r.Intn(6) {
+				case 0:
+					m.Store(key, i)
+				case 1:
+					m.LoadOrStore(key, i)
+				case 2:
+					m.Swap(key, i)
+				case 3:
+					m.Delete(key)
+				case 4:
+					m.LoadAndDelete(key)
+				case 5:
+					m.CompareAndDelete(key, i)
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	// Count actual entries via Range
+	actual := 0
+	m.Range(func(k, v int) bool {
+		actual++
+		return true
+	})
+
+	if got := m.Len(); got != actual {
+		t.Fatalf("after concurrent ops, Len() = %d, but Range counted %d entries", got, actual)
+	}
+}
+
+func TestMapLenConcurrentStoreDelete(t *testing.T) {
+	// Stress test: many goroutines store unique keys then delete them all.
+	// Final Len() must be 0.
+	var m gache.Map[int, int]
+
+	const (
+		numGoroutines    = 8
+		keysPerGoroutine = 500
+	)
+
+	var wg sync.WaitGroup
+	// Phase 1: Store unique keys per goroutine
+	for g := range numGoroutines {
+		wg.Go(func() {
+			base := g * keysPerGoroutine
+			for i := range keysPerGoroutine {
+				m.Store(base+i, i)
+			}
+		})
+	}
+
+	// Phase 1 also: concurrent deletions (some will miss, that's fine)
+	for g := range numGoroutines {
+		wg.Go(func() {
+			base := g * keysPerGoroutine
+			for i := range keysPerGoroutine {
+				m.Delete(base + i)
+			}
+		})
+	}
+	wg.Wait()
+
+	// Now delete anything remaining
+	m.Range(func(k, v int) bool {
+		m.Delete(k)
+		return true
+	})
+
+	if got := m.Len(); got != 0 {
+		t.Fatalf("after storing and deleting all keys, Len() = %d, want 0", got)
+	}
+}
+
+func TestMapLenClearConcurrent(t *testing.T) {
+	// Verify that Clear() under concurrent Store/Delete doesn't corrupt the counter.
+	var m gache.Map[int, int]
+
+	const (
+		numWriters  = 4
+		numDeleters = 4
+		ops         = 500
+	)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writers
+	for id := range numWriters {
+		wg.Go(func() {
+			r := rand.New(rand.NewSource(int64(id)))
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					m.Store(r.Intn(100), id)
+				}
+			}
+		})
+	}
+
+	// Deleters
+	for id := range numDeleters {
+		wg.Go(func() {
+			r := rand.New(rand.NewSource(int64(id + 100)))
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					m.Delete(r.Intn(100))
+				}
+			}
+		})
+	}
+
+	// Periodically Clear and check that Len doesn't go negative
+	for range ops {
+		m.Clear()
+		if l := m.Len(); l < 0 {
+			t.Fatalf("Len() = %d after Clear, must not be negative", l)
+		}
+	}
+
+	close(done)
+	wg.Wait()
+
+	// Final check: Len must match actual count
+	actual := 0
+	m.Range(func(k, v int) bool {
+		actual++
+		return true
+	})
+	if got := m.Len(); got != actual {
+		t.Fatalf("final Len() = %d, Range counted %d", got, actual)
 	}
 }


### PR DESCRIPTION
This pull request refactors the cache implementation to improve accuracy and efficiency in tracking item counts, and enhances the benchmarking suite for better configurability and determinism. The most notable changes are the shift from a global length counter to per-shard counters, the renaming of types for clarity, and the overhaul of the benchmark setup to support configurable parallelism and deterministic data.

### Cache implementation improvements

* Replaced the global `l` length counter in the `gache` struct with per-shard counters (`l` field in each `Map`), ensuring accurate item counts and thread safety. All operations that modify the count now update the relevant shard's counter instead of a global one. (`[[1]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL57-L62)`, `[[2]](diffhunk://#diff-5ed7da7003773d8e0a4dca00d4fc08fc5582695eefe22a400db15edfd5aab840R44)`, `[[3]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL279-R278)`, `[[4]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL299-R301)`, `[[5]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL369-R380)`, `[[6]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eR425-L424)`, `[[7]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL514-R521)`, `[[8]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL552-R555)`, `[[9]](diffhunk://#diff-5ed7da7003773d8e0a4dca00d4fc08fc5582695eefe22a400db15edfd5aab840R171)`)
* Updated the `Len()` method to sum per-shard counters, replacing the previous global atomic counter. (`[gache.goL369-R380](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL369-R380)`)
* Ensured that clearing the cache resets all shard counters, not just a global counter. (`[[1]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eR425-L424)`, `[[2]](diffhunk://#diff-5ed7da7003773d8e0a4dca00d4fc08fc5582695eefe22a400db15edfd5aab840R171)`)

### Type and naming refactor

* Renamed the `keyValue` struct to `kv` in the cache implementation for clarity and consistency, and updated all references accordingly. (`[[1]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL71-R70)`, `[[2]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL112-R111)`, `[[3]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL193-R193)`, `[[4]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL313-R313)`, `[[5]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL527-R530)`, `[[6]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL369-R380)`)
* Updated the channel type for expired items to use the new `kv` struct. (`[[1]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL57-L62)`, `[[2]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL112-R111)`, `[[3]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL313-R313)`, `[[4]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL527-R530)`, `[[5]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL369-R380)`)

### Benchmarking enhancements

* Introduced a `benchparallelism` flag for benchmarks, allowing configurable parallelism levels via command-line input, and defaulting to `[100, 1000, 5000, 10000]` if not specified. (`[[1]](diffhunk://#diff-84aeccf86740f7d05675f99d8abe2420a9ddbd78493dd14835725500ede4f04eR42-R92)`, `[[2]](diffhunk://#diff-84aeccf86740f7d05675f99d8abe2420a9ddbd78493dd14835725500ede4f04eR219-R230)`)
* Refactored benchmark data setup to use precomputed, sorted slices of `keyValue` pairs for deterministic iteration order, replacing random maps. (`[gache_benchmark_test.goR42-R92](diffhunk://#diff-84aeccf86740f7d05675f99d8abe2420a9ddbd78493dd14835725500ede4f04eR42-R92)`)
* Modified benchmark logic to run sub-benchmarks for each parallelism value, improving result granularity and reproducibility. (`[gache_benchmark_test.goL88-R147](diffhunk://#diff-84aeccf86740f7d05675f99d8abe2420a9ddbd78493dd14835725500ede4f04eL88-R147)`)
* Updated random string generation to use standard string conversion, improving safety and clarity. (`[gache_benchmark_test.goL88-R147](diffhunk://#diff-84aeccf86740f7d05675f99d8abe2420a9ddbd78493dd14835725500ede4f04eL88-R147)`)

### Miscellaneous

* Updated memory size accounting in `Size()` methods to include new fields. (`[[1]](diffhunk://#diff-d67d2e3e0cccfdfda8910660d78346b1c536ef7cb1779e7282ce80ffba14ce6eL369-R380)`, `[[2]](diffhunk://#diff-5ed7da7003773d8e0a4dca00d4fc08fc5582695eefe22a400db15edfd5aab840L540-R542)`)

These changes collectively improve cache correctness, maintainability, and benchmarking flexibility.